### PR TITLE
Fix line wrapping

### DIFF
--- a/full.css
+++ b/full.css
@@ -50,8 +50,6 @@ body cd-el {
   font-size: inherit;
   position: relative;
   box-sizing: border-box;
-  white-space: pre;
-  word-wrap: normal;
   padding-bottom: calc(41px + 10.5px);
   scroll-padding-bottom: calc(41px + 10.5px);
 }


### PR DESCRIPTION
Resolves https://github.com/codeitcodes/codeit/issues/182

Two lines on `full.css` were overwriting the CSS on the head element from `codeit.js`. This PR removes them and adds line wrapping to the editor.

I mainly use this on mobile to edit notes, but I can see how having line wrapping on all the time can be annoying sometimes. I think it'd work better if we had a way to toggle line wrapping on and off by changing `white-space: pre-wrap` to `white-space: pre` and vice-versa. Feel free to let me know what you think 🤔

## Screenshots
Before (Desktop & Mobile):
![スクリーンショット 2024-12-04 052458](https://github.com/user-attachments/assets/602bda66-8f47-4968-83a1-9d337909b4b6)
![Screen Shot 2024-12-04 at 05 23 50](https://github.com/user-attachments/assets/5f229cab-54f0-4b52-9b38-eb15acb6d6af)

After (Desktop & Mobile):
![スクリーンショット 2024-12-04 052528](https://github.com/user-attachments/assets/22a81c56-6ed8-4846-a886-46c0326ab6c3)
![Screen Shot 2024-12-04 at 05 24 06](https://github.com/user-attachments/assets/e6890620-1efc-4bb3-affc-c29d81e6774a)